### PR TITLE
[DSPLATFORM-924] 전체데이터 다운로드 기준 설정 추가 및 현 제플린운영 미반영된 코드 추가

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -189,7 +189,7 @@ if [[ ! -z "$ZEPPELIN_IMPERSONATE_USER" ]]; then
     if [[ -n  "${suid}" || -z "${SPARK_SUBMIT}" ]]; then
        INTERPRETER_RUN_COMMAND=${ZEPPELIN_IMPERSONATE_RUN_CMD}" '"
        if [[ -f "${ZEPPELIN_CONF_DIR}/zeppelin-env.sh" ]]; then
-           INTERPRETER_RUN_COMMAND+=" source "${ZEPPELIN_CONF_DIR}'/zeppelin-env.sh;'
+           INTERPRETER_RUN_COMMAND+=" source "${ZEPPELIN_CONF_DIR}'/zeppelin-env.sh;'" export PYTHONPATH=$PYTHONPATH; export ZEPPELIN_HOME=$ZEPPELIN_HOME;"
        fi
     fi
 fi

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -362,5 +362,21 @@
   <value>1</value>
   <description>The HTTP X-XSS-Protection response header is a feature of Internet Explorer, Chrome and Safari that stops pages from loading when they detect reflected cross-site scripting (XSS) attacks. When value is set to 1 and a cross-site scripting attack is detected, the browser will sanitize the page (remove the unsafe parts).</description>
 </property>
+  <value>origin</value>
+  <description>Git repository remote</description>
+</property>
+-->
+
+<!--
+<property>
+  <name>zeppelin.notebook.cron.enable</name>
+  <value>false</value>
+  <description>Notebook enable cron scheduler feature</description>
+</property>
+<property>
+  <name>zeppelin.notebook.cron.folders</name>
+  <value></value>
+  <description>Notebook cron folders</description>
+</property>
 -->
 </configuration>

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -311,6 +311,12 @@
 </property>
 
 <property>
+  <name>zeppelin.notebook.default.owner.username</name>
+  <value></value>
+  <description>Set owner role by default</description>
+</property>
+
+<property>
   <name>zeppelin.notebook.public</name>
   <value>true</value>
   <description>Make notebook public by default when created, private otherwise</description>

--- a/docs/usage/other_features/cron_scheduler.md
+++ b/docs/usage/other_features/cron_scheduler.md
@@ -1,0 +1,60 @@
+---
+layout: page
+title: "Running a Notebook on a Given Schedule Automatically"
+description: "You can run a notebook on a given schedule automatically by setting up a cron scheduler on the notebook."
+group: usage/other_features
+---
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+{% include JB/setup %}
+
+# Running a Notebook on a Given Schedule Automatically
+
+<div id="toc"></div>
+
+Apache Zeppelin provides a cron scheduler for each notebook. You can run a notebook on a given schedule automatically by setting up a cron scheduler on the notebook.
+
+## Setting up a cron scheduler on a notebook
+
+Click the clock icon on the tool bar and open a cron scheduler dialog box.
+
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/cron_scheduler_dialog_box.png" />
+
+There are the following items which you can input or set:
+
+### Preset
+
+You can set a cron schedule easily by clicking each option such as `1m` and `5m`. The login user is set as a cron executing user automatically. You can also clear the cron schedule settings by clicking `None`.
+
+### Cron expression
+
+You can set the cron schedule by filling in this form. Please see [Cron Trigger Tutorial](http://www.quartz-scheduler.org/documentation/quartz-2.2.x/tutorials/crontrigger) for the available cron syntax.
+
+### Cron executing user
+
+You can set the cron executing user by filling in this form and press the enter key.
+
+### auto-restart interpreter on cron execution
+
+When this checkbox is set to "on", the interpreters which are binded to the notebook are stopped automatically after the cron execution. This feature is useful if you want to release the interpreter resources after the cron execution.
+
+> **Note**: A cron execution is skipped if one of the paragraphs is in a state of `RUNNING` or `PENDING` no matter whether it is executed automatically (i.e. by the cron scheduler) or manually by a user opening this notebook.
+
+### Enable cron
+
+Set property **zeppelin.notebook.cron.enable** to **true** in `$ZEPPELIN_HOME/conf/zeppelin-site.xml` to enable Cron feature.
+
+### Run cron selectively on folders
+
+In `$ZEPPELIN_HOME/conf/zeppelin-site.xml` make sure the property **zeppelin.notebook.cron.enable** is set to **true**, and then set property **zeppelin.notebook.cron.folders** to the desired folder as comma-separated values, e.g. `*yst*, Sys?em, System`. This property accepts wildcard and joker.

--- a/presto/src/main/java/org/apache/zeppelin/presto/PrestoInterpreter.java
+++ b/presto/src/main/java/org/apache/zeppelin/presto/PrestoInterpreter.java
@@ -270,9 +270,10 @@ public class PrestoInterpreter extends Interpreter {
     synchronized (prestoSessions) {
       ClientSession prestoSession = prestoSessions.get(userId);
       if (prestoSession == null) {
+        String user = (prestoUser != null && prestoUser.length() > 0) ? prestoUser : userId;
         prestoSession = new ClientSession(
             prestoServer,
-            prestoUser,
+            user,
             prestoSourcePrefix + userId,
             Collections.singleton("zeppelin-presto-interpreter"),
             "Zeppelin Presto Interpreter",

--- a/presto/src/main/resources/interpreter-setting.json
+++ b/presto/src/main/resources/interpreter-setting.json
@@ -70,6 +70,12 @@
         "propertyName": "presto.highlight_limit",
         "defaultValue": "true",
         "description": "Highlighting Limit"
+      },
+      "presto.full_download.rows.min": {
+        "envName": null,
+        "propertyName": "presto.full_download.rows.min",
+        "defaultValue": "1000",
+        "description": "Minimum Rows Count to Activate Full Download"
       }
     },
     "editor": {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -617,13 +617,21 @@ public class NotebookRestApi {
     if (file.exists()) {
       LOG.info("Download data from " + file);
       response = Response.ok((Object) file);
+      response.header("Content-Disposition", "attachment; filename=\"" + fileName + ".csv\"");
+      response.type(MediaType.TEXT_PLAIN + "; charset=UTF-8");
     } else {
       LOG.info("Download data from paragraph result " +
               "because result file is not exists: " + file);
-      response = Response.ok(p.getResultMessage());
+      response = Response.ok("<html>\n" +
+              "<head><meta charset=\"UTF-8\"></head>\n" +
+              "<script language=\"javascript\">\n" +
+              "window.alert(\"저장된 전체데이터가 없습니다.\\n\\n" +
+              "데이터 유효기간(1일)이 지났을 수 있습니다. 쿼리를 다시 실행시켜주세요.\")\n\n" +
+              "window.close()\n" +
+              "</script>\n" +
+              "</html>");
+      response.type(MediaType.TEXT_HTML + "; charset=UTF-8");
     }
-    response.header("Content-Disposition", "attachment; filename=\"" + fileName + ".csv\"");
-    response.type(MediaType.TEXT_PLAIN + "; charset=UTF-8");
     return response.build();
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -151,7 +151,7 @@ public class NotebookRestApi {
       throw new ForbiddenException(errorMsg);
     }
   }
-  
+
   /**
    * Check if the current user is either Owner or Writer for the given note.
    */
@@ -163,7 +163,7 @@ public class NotebookRestApi {
       throw new ForbiddenException(errorMsg);
     }
   }
-  
+
   /**
    * Check if the current user can access (at least he have to be reader) the given note.
    */
@@ -175,19 +175,26 @@ public class NotebookRestApi {
       throw new ForbiddenException(errorMsg);
     }
   }
-  
+
   private void checkIfNoteIsNotNull(Note note) {
     if (note == null) {
       throw new NotFoundException("note not found");
     }
   }
-  
+
+  private void checkIfNoteSupportsCron(Note note) {
+    if (!note.isCronSupported(notebook.getConf())) {
+      LOG.error("Cron is not enabled from Zeppelin server");
+      throw new ForbiddenException("Cron is not enabled from Zeppelin server");
+    }
+  }
+
   private void checkIfParagraphIsNotNull(Paragraph paragraph) {
     if (paragraph == null) {
       throw new NotFoundException("paragraph not found");
     }
   }
-  
+
   /**
    * set note authorization information
    */
@@ -205,7 +212,7 @@ public class NotebookRestApi {
     checkIfUserIsAnon(getBlockNotAuthenticatedUserErrorMsg());
     checkIfUserIsOwner(noteId,
         ownerPermissionError(userAndRoles, notebookAuthorization.getOwners(noteId)));
-    
+
     HashMap<String, HashSet<String>> permMap =
         gson.fromJson(req, new TypeToken<HashMap<String, HashSet<String>>>() {}.getType());
     Note note = notebook.getNote(noteId);
@@ -365,6 +372,7 @@ public class NotebookRestApi {
 
     note.setName(noteName);
     note.persist(subject);
+    note.setCronSupported(notebook.getConf());
     notebookServer.broadcastNote(note);
     notebookServer.broadcastNoteList(subject, SecurityUtils.getRoles());
     return new JsonResponse<>(Status.CREATED, "", note.getId()).build();
@@ -724,7 +732,7 @@ public class NotebookRestApi {
   @GET
   @Path("job/{noteId}/{paragraphId}")
   @ZeppelinApi
-  public Response getNoteParagraphJobStatus(@PathParam("noteId") String noteId, 
+  public Response getNoteParagraphJobStatus(@PathParam("noteId") String noteId,
       @PathParam("paragraphId") String paragraphId)
       throws IOException, IllegalArgumentException {
     LOG.info("get note paragraph job status.");
@@ -859,6 +867,7 @@ public class NotebookRestApi {
     Note note = notebook.getNote(noteId);
     checkIfNoteIsNotNull(note);
     checkIfUserCanWrite(noteId, "Insufficient privileges you cannot set a cron job for this note");
+    checkIfNoteSupportsCron(note);
 
     if (!CronExpression.isValidExpression(request.getCronString())) {
       return new JsonResponse<>(Status.BAD_REQUEST, "wrong cron expressions.").build();
@@ -885,11 +894,12 @@ public class NotebookRestApi {
   public Response removeCronJob(@PathParam("noteId") String noteId)
       throws IOException, IllegalArgumentException {
     LOG.info("Remove cron job note {}", noteId);
-
+    
     Note note = notebook.getNote(noteId);
     checkIfNoteIsNotNull(note);
     checkIfUserIsOwner(noteId,
         "Insufficient privileges you cannot remove this cron job from this note");
+    checkIfNoteSupportsCron(note);
 
     Map<String, Object> config = note.getConfig();
     config.put("cron", null);
@@ -916,6 +926,7 @@ public class NotebookRestApi {
     Note note = notebook.getNote(noteId);
     checkIfNoteIsNotNull(note);
     checkIfUserCanRead(noteId, "Insufficient privileges you cannot get cron information");
+    checkIfNoteSupportsCron(note);
 
     return new JsonResponse<>(Status.OK, note.getConfig().get("cron")).build();
   }
@@ -1013,5 +1024,4 @@ public class NotebookRestApi {
       }
     }
   }
-
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -766,7 +766,7 @@ public class NotebookServer extends WebSocketServlet
   }
 
   private void updateNote(NotebookSocket conn, HashSet<String> userAndRoles, Notebook notebook,
-      Message fromMessage) throws SchedulerException, IOException {
+      Message fromMessage) throws IOException {
     String noteId = (String) fromMessage.get("id");
     String name = (String) fromMessage.get("name");
     Map<String, Object> config = (Map<String, Object>) fromMessage.get("config");
@@ -786,6 +786,11 @@ public class NotebookServer extends WebSocketServlet
 
     Note note = notebook.getNote(noteId);
     if (note != null) {
+      if (!(Boolean) note.getConfig().get("isZeppelinNotebookCronEnable")) {
+        if (config.get("cron") != null) {
+          config.remove("cron");
+        }
+      }
       boolean cronUpdated = isCronUpdated(config, note.getConfig());
       note.setName(name);
       note.setConfig(config);
@@ -853,6 +858,7 @@ public class NotebookServer extends WebSocketServlet
     Note note = notebook.getNote(noteId);
     if (note != null) {
       note.setName(name);
+      note.setCronSupported(notebook.getConf());
 
       AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
       note.persist(subject);
@@ -945,6 +951,7 @@ public class NotebookServer extends WebSocketServlet
           noteName = "Note " + note.getId();
         }
         note.setName(noteName);
+        note.setCronSupported(notebook.getConf());
       }
 
       note.persist(subject);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -29,6 +29,7 @@ import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.server.ZeppelinServer;
@@ -369,7 +370,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Map config = paragraph.getConfig();
     config.put("enabled", true);
     paragraph.setConfig(config);
-    
+
     paragraph.setText("%md This is test paragraph.");
     note.persist(anonymous);
     String noteId = note.getId();
@@ -384,7 +385,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
         break;
       }
     }
-    
+
     // Call Run note jobs REST API
     PostMethod postNoteJobs = httpPost("/notebook/job/" + noteId, "");
     assertThat("test note jobs run:", postNoteJobs, isAllowed());
@@ -393,21 +394,21 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     // Call Stop note jobs REST API
     DeleteMethod deleteNoteJobs = httpDelete("/notebook/job/" + noteId);
     assertThat("test note stop:", deleteNoteJobs, isAllowed());
-    deleteNoteJobs.releaseConnection();    
+    deleteNoteJobs.releaseConnection();
     Thread.sleep(1000);
-    
+
     // Call Run paragraph REST API
     PostMethod postParagraph = httpPost("/notebook/job/" + noteId + "/" + paragraph.getId(), "");
     assertThat("test paragraph run:", postParagraph, isAllowed());
-    postParagraph.releaseConnection();    
+    postParagraph.releaseConnection();
     Thread.sleep(1000);
-    
+
     // Call Stop paragraph REST API
     DeleteMethod deleteParagraph = httpDelete("/notebook/job/" + noteId + "/" + paragraph.getId());
     assertThat("test paragraph stop:", deleteParagraph, isAllowed());
-    deleteParagraph.releaseConnection();    
+    deleteParagraph.releaseConnection();
     Thread.sleep(1000);
-    
+
     //cleanup
     ZeppelinServer.notebook.removeNote(note.getId(), anonymous);
   }
@@ -519,7 +520,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     note.setName("note for run test");
     Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     paragraph.setText("%md This is test paragraph.");
-    
+
     Map config = paragraph.getConfig();
     config.put("enabled", true);
     paragraph.setConfig(config);
@@ -540,20 +541,20 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     PostMethod postCron = httpPost("/notebook/cron/notexistnote", jsonRequest);
     assertThat("", postCron, isNotFound());
     postCron.releaseConnection();
-    
+
     // right cron expression.
     postCron = httpPost("/notebook/cron/" + note.getId(), jsonRequest);
     assertThat("", postCron, isAllowed());
     postCron.releaseConnection();
     Thread.sleep(1000);
-    
+
     // wrong cron expression.
     jsonRequest = "{\"cron\":\"a * * * * ?\" }";
     postCron = httpPost("/notebook/cron/" + note.getId(), jsonRequest);
     assertThat("", postCron, isBadRequest());
     postCron.releaseConnection();
     Thread.sleep(1000);
-    
+
     // remove cron job.
     DeleteMethod deleteCron = httpDelete("/notebook/cron/" + note.getId());
     assertThat("", deleteCron, isAllowed());

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -188,7 +188,7 @@ limitations under the License.
       </span>
 
       <span ng-hide="viewOnly">
-      <div class="labelBtn btn-group">
+      <div class="labelBtn btn-group" ng-if="note.config.isZeppelinNotebookCronEnable">
         <div class="btn btn-default btn-xs dropdown-toggle"
              type="button"
              data-toggle="dropdown"

--- a/zeppelin-web/src/app/notebook/paragraph/result/result-chart-selector.html
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result-chart-selector.html
@@ -89,6 +89,7 @@ limitations under the License.
   <ul class="dropdown-menu" role="menu" style="min-width: 70px;">
     <li ng-click="exportToDSV(',')"><a>CSV</a></li>
     <li ng-click="exportToDSV('\t')"><a>TSV</a></li>
+    <li ng-click="downloadParagraph()"><a>Full CSV</a></li>
   </ul>
 </div>
 

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -647,6 +647,11 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
     saveAsService.saveAs(dsv, exportedFileName, extension);
   };
 
+  $scope.downloadParagraph = function() {
+    console.log('Download node: %o paragraph: %o', $scope.note.id, $scope.paragraph.id);
+    saveAsService.downloadParagraph($scope.note.id, $scope.paragraph.id, $scope.note, $scope.note.name, 'csv');
+  };
+
   $scope.getBase64ImageSrc = function(base64Data) {
     return 'data:image/png;base64,' + base64Data;
   };

--- a/zeppelin-web/src/components/saveAs/saveAs.service.js
+++ b/zeppelin-web/src/components/saveAs/saveAs.service.js
@@ -14,9 +14,12 @@
 
 angular.module('zeppelinWebApp').service('saveAsService', saveAsService);
 
-saveAsService.$inject = ['browserDetectService'];
+saveAsService.$inject = [
+  'browserDetectService',
+  'baseUrlSrv'
+];
 
-function saveAsService(browserDetectService) {
+function saveAsService(browserDetectService, baseUrlSrv) {
   this.saveAs = function(content, filename, extension) {
     var BOM = '\uFEFF';
     if (browserDetectService.detectIE()) {
@@ -70,7 +73,8 @@ function saveAsService(browserDetectService) {
     } else {
       angular.element('body').append('<a id="SaveAsId"></a>');
       var saveAsElement = angular.element('body > a#SaveAsId');
-      saveAsElement.attr('href', '/api/notebook/' + noteId + '/paragraph/' + paragraphId + '/download');
+      var apiPath = baseUrlSrv.getRestApiBase()  + '/notebook/' + noteId + '/paragraph/' + paragraphId + '/download';
+      saveAsElement.attr('href', apiPath);
       saveAsElement.attr('target', '_blank');
       saveAsElement[0].click();
       saveAsElement.remove();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -493,6 +493,14 @@ public class ZeppelinConfiguration extends XMLConfiguration {
   }
 
 
+  public Boolean isZeppelinNotebookCronEnable() {
+    return getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE);
+  }
+
+  public String getZeppelinNotebookCronFolders() {
+    return getString(ConfVars.ZEPPELIN_NOTEBOOK_CRON_FOLDERS);
+  }
+
   public Map<String, String> dumpConfigurations(ZeppelinConfiguration conf,
                                                 ConfigurationKeyPredicate predicate) {
     Map<String, String> configurations = new HashMap<>();
@@ -641,6 +649,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_SERVER_JETTY_NAME("zeppelin.server.jetty.name", null),
     ZEPPELIN_SERVER_STRICT_TRANSPORT("zeppelin.server.strict.transport", "max-age=631138519"),
     ZEPPELIN_SERVER_X_XSS_PROTECTION("zeppelin.server.xxss.protection", "1"),
+    ZEPPELIN_NOTEBOOK_CRON_ENABLE("zeppelin.notebook.cron.enable", false),
+    ZEPPELIN_NOTEBOOK_CRON_FOLDERS("zeppelin.notebook.cron.folders", null),
     ZEPPELIN_OWNER_ROLE("zeppelin.notebook.default.owner.username", "");
 
     private String varName;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -640,7 +640,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_SERVER_XFRAME_OPTIONS("zeppelin.server.xframe.options", "SAMEORIGIN"),
     ZEPPELIN_SERVER_JETTY_NAME("zeppelin.server.jetty.name", null),
     ZEPPELIN_SERVER_STRICT_TRANSPORT("zeppelin.server.strict.transport", "max-age=631138519"),
-    ZEPPELIN_SERVER_X_XSS_PROTECTION("zeppelin.server.xxss.protection", "1");
+    ZEPPELIN_SERVER_X_XSS_PROTECTION("zeppelin.server.xxss.protection", "1"),
+    ZEPPELIN_OWNER_ROLE("zeppelin.notebook.default.owner.username", "");
 
     private String varName;
     @SuppressWarnings("rawtypes")

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
@@ -24,7 +24,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -35,6 +34,7 @@ import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -259,17 +259,28 @@ public class NotebookAuthorization {
   }
 
   public boolean isOwner(String noteId, Set<String> entities) {
-    return isMember(entities, getOwners(noteId));
+    return isMember(entities, getOwners(noteId)) || isAdmin(entities);
   }
 
   public boolean isWriter(String noteId, Set<String> entities) {
-    return isMember(entities, getWriters(noteId)) || isMember(entities, getOwners(noteId));
+    return isMember(entities, getWriters(noteId)) ||
+           isMember(entities, getOwners(noteId)) ||
+           isAdmin(entities);
   }
 
   public boolean isReader(String noteId, Set<String> entities) {
     return isMember(entities, getReaders(noteId)) ||
             isMember(entities, getOwners(noteId)) ||
-            isMember(entities, getWriters(noteId));
+            isMember(entities, getWriters(noteId)) ||
+           isAdmin(entities);
+  }
+
+  private boolean isAdmin(Set<String> entities) {
+    String adminRole = conf.getString(ConfVars.ZEPPELIN_OWNER_ROLE);
+    if (StringUtils.isBlank(adminRole)) {
+      return false;
+    }
+    return entities.contains(adminRole);
   }
 
   // return true if b is empty or if (a intersection b) is non-empty


### PR DESCRIPTION
https://jira.woowa.in/browse/DSPLATFORM-924

전체데이터 다운로드 기준 설정 추가 작업입니다.
현재 운영중인 제플린에 반영되어있지만, master branch에 반영되지 않은 코드도 추가했습니다.
(presto-0.7 branch 내용 중 일부)

반영내용
- 전체다운로드 기준 row 수 조절하는 property 추가
- `Save As` selectbox에 `Full CSV` 추가 (구름모양과 기능 동일)
- Full CSV 시, 버그 수정
    - 받아야할 DataFile 없을 시, Notebook의 데이터를 내려받도록 구현되어있었는데, 0.7 수정사항이 반영되지 않아서 동작하지 않았던 것으로 추정.
- Full CSV 시, 파일 없을 때 메세지 보이도록 추가